### PR TITLE
enh: implement cleanup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ functions:
 flags: 
     --help/-h: Display this page
     
-    --description/-d: By default, $(basename $0) will only display packages 
+    --description/-d: By default, rhino-pkg will only display packages 
     that contain <input> within their name. Use this flag to increase 
     range and display packages with <input> in their description.
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,20 @@ functions:
     
     update:  Updates all packages accessible to the wrapper - does
              not accept <input>, instead use install to update 
-             individual packages. Has confirmation prompt.
+             individual packages. Has a confirmation prompt.
+
+    cleanup: Attempts to repair broken dependencies and remove any
+             unused packages. Does not accept <input>, but has 
+             a confirmation prompt.
 
 flags: 
     --help/-h: Display this page
     
-    --description/-d: By default, rhino-pkg will only display packages 
+    --description/-d: By default, $(basename $0) will only display packages 
     that contain <input> within their name. Use this flag to increase 
     range and display packages with <input> in their description.
+
+    -y: Makes functions with confirmation prompts run promptless.
     
 input: 
     Provide a package name or description.

--- a/rhino-pkg
+++ b/rhino-pkg
@@ -202,9 +202,9 @@ if [[ -n $UPDATE ]]; then
     esac
     if command -v nala &> /dev/null; then
         if [[ -n $PROMPTLESS ]]; then
-            sudo nala upgrade -y -o Acquire::AllowReleaseInfoChange="true"
+            sudo nala upgrade -y --full --no-autoremove -o Acquire::AllowReleaseInfoChange="true"
         else
-            sudo nala upgrade -o Acquire::AllowReleaseInfoChange="true"
+            sudo nala upgrade --full --no-autoremove -o Acquire::AllowReleaseInfoChange="true"
         fi
     else
         if [[ -n $PROMPTLESS ]]; then

--- a/rhino-pkg
+++ b/rhino-pkg
@@ -125,9 +125,9 @@ function search_apt() {
 
 function search_flatpak() {
     if [[ -z $DESCRIPTION ]]; then
-        local contents=("$(LC_ALL=C flatpak search --columns="application" "$*" | grep -i --color=never "$*")")
+        local contents=("$(LC_ALL=C sudo flatpak search --columns="application" "$*" | grep -i --color=never "$*")")
     else
-        local contents=("$(LC_ALL=C flatpak search --columns="application" "$*")")
+        local contents=("$(LC_ALL=C sudo flatpak search --columns="application" "$*")")
     fi
     if [[ ${contents[*]} == "No matches found" ]]; then
         return 1
@@ -341,7 +341,7 @@ esac
 for i in "${entered_input[@]}"; do
     case "${pkgrepo[i]}" in
         flatpak)
-            flatpak "${flatpak_cmd}" "${pkgs[i]}" -y
+            sudo flatpak "${flatpak_cmd}" "${pkgs[i]}" -y
             ret=$?
             ;;
         apt)

--- a/rhino-pkg
+++ b/rhino-pkg
@@ -162,6 +162,10 @@ case "${1}" in
         REMOVE=true
         shift
         ;;
+    cleanup)
+        CLEANUP=true
+        shift
+        ;;
     update)
         UPDATE=true
         shift
@@ -231,6 +235,47 @@ if [[ -n $UPDATE ]]; then
     fi
     if command -v snap &> /dev/null; then
         sudo snap refresh
+    fi
+    exit 0
+fi
+
+if [[ -n $CLEANUP ]]; then
+    if [[ -n $* ]]; then
+        exit 1
+    fi
+    if [[ -z $PROMPTLESS ]]; then
+        echo -n $"This will attempt to repair broken dependencies and remove unused packages. Do you want to continue? (${BGreen}y${NC}/${BRed}N${NC}) "
+        read -ra read_update
+        echo -ne "${NC}"
+    else
+        read_update=("Y")
+    fi
+    case "${read_update[0]}" in
+        Y* | y*) ;;
+        *) exit 1 ;;
+    esac
+    if command -v nala &> /dev/null; then
+        if [[ -n $PROMPTLESS ]]; then
+            sudo nala install && sudo nala upgrade -y --full --no-update -o Acquire::AllowReleaseInfoChange="true"
+        else
+            sudo nala install && sudo nala upgrade --full --no-update -o Acquire::AllowReleaseInfoChange="true"
+        fi
+    else
+        if [[ -n $PROMPTLESS ]]; then
+            sudo apt --fix-broken install && sudo apt auto-remove -y
+        else
+            sudo apt --fix-broken install && sudo apt auto-remove
+        fi
+    fi
+    if command -v flatpak &> /dev/null; then
+        if [[ -n $PROMPTLESS ]]; then
+            flatpak repair && flatpak uninstall --unused -y
+        else
+            flatpak repair && flatpak uninstall --unused
+        fi
+    fi
+    if command -v snap &> /dev/null; then
+        LANG=C snap list --all | while read snapname ver rev trk pub notes; do if [[ $notes = *disabled* ]]; then sudo snap remove "$snapname" --revision="$rev"; fi; done
     fi
     exit 0
 fi

--- a/rhino-pkg
+++ b/rhino-pkg
@@ -279,9 +279,9 @@ if [[ -n $CLEANUP ]]; then
     fi
     if command -v flatpak &> /dev/null; then
         if [[ -n $PROMPTLESS ]]; then
-            flatpak repair && sudo flatpak uninstall --unused -y
+            sudo flatpak repair && sudo flatpak uninstall --unused -y
         else
-            flatpak repair && sudo flatpak uninstall --unused
+            sudo flatpak repair && sudo flatpak uninstall --unused
         fi
     fi
     if command -v snap &> /dev/null; then

--- a/rhino-pkg
+++ b/rhino-pkg
@@ -80,7 +80,7 @@ ${c3}   ''''''''${c2}kXOM.
 ${c3}     .,,:${c2}dXMK           
 ${c3}       ${c2}:k
 
-$(basename "$0") 0.1.1
+$(basename "$0") 0.1.2
 A package manager wrapper for Pacstall, APT, Flatpak and snap
 Developed by Elsie19 <elsie19@pm.me> for
 the Rhino Linux distribution."

--- a/rhino-pkg
+++ b/rhino-pkg
@@ -37,7 +37,11 @@ functions:
     
     update:  Updates all packages accessible to the wrapper - does
              not accept <input>, instead use install to update 
-             individual packages. Has confirmation prompt.
+             individual packages. Has a confirmation prompt.
+
+    cleanup: Attempts to repair broken dependencies and remove any
+             unused packages. Does not accept <input>, but has 
+             a confirmation prompt.
 
 flags: 
     --help/-h: Display this page
@@ -45,6 +49,8 @@ flags:
     --description/-d: By default, $(basename $0) will only display packages 
     that contain <input> within their name. Use this flag to increase 
     range and display packages with <input> in their description.
+
+    -y: Makes functions with confirmation prompts run promptless.
     
 input: 
     Provide a package name or description.
@@ -165,6 +171,10 @@ case "${1}" in
     cleanup)
         CLEANUP=true
         shift
+        if [[ $1 == "-y" ]]; then
+            PROMPTLESS=true
+            shift
+        fi
         ;;
     update)
         UPDATE=true
@@ -244,7 +254,7 @@ if [[ -n $CLEANUP ]]; then
         exit 1
     fi
     if [[ -z $PROMPTLESS ]]; then
-        echo -n $"This will attempt to repair broken dependencies and remove unused packages. Do you want to continue? (${BGreen}y${NC}/${BRed}N${NC}) "
+        echo -n $"Attempting to repair dependencies and remove unused packages. Continue? (${BGreen}y${NC}/${BRed}N${NC}) "
         read -ra read_update
         echo -ne "${NC}"
     else
@@ -256,9 +266,9 @@ if [[ -n $CLEANUP ]]; then
     esac
     if command -v nala &> /dev/null; then
         if [[ -n $PROMPTLESS ]]; then
-            sudo nala install && sudo nala upgrade -y --full --no-update -o Acquire::AllowReleaseInfoChange="true"
+            sudo nala install --fix-broken && sudo nala autoremove -y
         else
-            sudo nala install && sudo nala upgrade --full --no-update -o Acquire::AllowReleaseInfoChange="true"
+            sudo nala install --fix-broken && sudo nala autoremove
         fi
     else
         if [[ -n $PROMPTLESS ]]; then
@@ -269,13 +279,15 @@ if [[ -n $CLEANUP ]]; then
     fi
     if command -v flatpak &> /dev/null; then
         if [[ -n $PROMPTLESS ]]; then
-            flatpak repair && flatpak uninstall --unused -y
+            flatpak repair && sudo flatpak uninstall --unused -y
         else
-            flatpak repair && flatpak uninstall --unused
+            flatpak repair && sudo flatpak uninstall --unused
         fi
     fi
     if command -v snap &> /dev/null; then
-        LANG=C snap list --all | while read snapname ver rev trk pub notes; do if [[ $notes = *disabled* ]]; then sudo snap remove "$snapname" --revision="$rev"; fi; done
+        if [[ -z "$(LANG=C snap list --all | while read snapname ver rev trk pub notes; do if [[ "$notes" == *disabled* ]]; then sudo snap remove "$snapname" --revision="$rev"; fi; done)" ]]; then
+            echo "Nothing for snap to clean."
+        fi
     fi
     exit 0
 fi


### PR DESCRIPTION
Builds on top of https://github.com/rhino-linux/rhino-pkg/pull/33, adding a new `rhino-pkg cleanup {-y}` command.


Closes https://github.com/rhino-linux/rhino-pkg/issues/32